### PR TITLE
Add macOS builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,14 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
     uses: carlthome/workflows/.github/workflows/nix.yaml@main
     with:
       cachix-cache: carlthome
+      runs-on: ${{ matrix.os }}
     secrets:
       cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Not sure if this will work in GitHub Actions but would be nice to CI check that the build expressions behave on both Linux and Mac.