### PR TITLE
One step forward building the `lameenc`

### DIFF
--- a/pkgs/development/python-modules/lameenc/default.nix
+++ b/pkgs/development/python-modules/lameenc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3
 , fetchFromGitHub
+, fetchurl
 , lame
 , cmake
 , stdenv
@@ -8,15 +9,27 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "lameenc";
-  version = "1.6.1";
+  version = "1.7.0";
   format = "other";
 
-  src = fetchFromGitHub {
-    owner = "chrisstaite";
-    repo = "lameenc";
-    rev = "v${version}";
-    hash = "sha256-+EnJ4v6Ol5tnFKpFCx8w1Bhu5NsaIK1OX/sjEhnMHL8=";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "chrisstaite";
+      repo = "lameenc";
+      rev = "v${version}";
+      name = pname;
+      hash = "sha256-anZEJNr9eZP94fTkrzXoC8uxVoItaGgVj4jQZinQtoo=";
+    })
+    (fetchurl {
+      url = "https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz/download";
+      hash = "sha256-3f42yrhzeUA4riwSEFV600hXpLa9xRV4XR2p4XWx2h4=";
+      name = "lame-3.100.tar.gz";
+    })
+  ];
+
+  sourceRoot = pname;
+
+  patches = [ ./no-download.patch ];
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools

--- a/pkgs/development/python-modules/lameenc/no-download.patch
+++ b/pkgs/development/python-modules/lameenc/no-download.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b2648c..4e71264 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,9 +56,7 @@ endif ()
+ include(ExternalProject)
+ ExternalProject_Add(lame
+     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/lame"
+-    URL https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz/download
+-    URL_HASH SHA256=ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+-    DOWNLOAD_NO_PROGRESS 1
++    SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../lame-3.100"
+     PATCH_COMMAND "${CMAKE_COMMAND}" 
+         -D "SOURCE_DIR=<SOURCE_DIR>"
+         -P "${CMAKE_CURRENT_SOURCE_DIR}/patch-lame.cmake"


### PR DESCRIPTION
Was able to build it, but it fails at the `pythonImportsCheckPhase` with `ImportError:
/nix/store/xbwdpznnj58pv4bm2b73vyk0dk2rznxr-python3.11-lameenc-1.7.0/lib/python3.11/site-packages/lameenc.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZGVbN2v_exp`

Maybe you or someone could continue.

The problem was that `CMake` used the `ExternalProject_Add` command with `URL` option trying to download `lame` sources which didn't work in `stdenv`.

https://cmake.org/cmake/help/latest/module/ExternalProject.html#id2

Turns out it was possible to:
* Have 2 source sets, both for the `lameenc` and `lame`.
  - https://nixos.org/manual/nixpkgs/stable/#variables-controlling-the-unpack-phase
* Create a patch to point `CMake` to the local `lame` sources instead of downloading them from the URL.
  - https://cmake.org/cmake/help/latest/module/ExternalProject.html#directory-options