### PR TITLE
audiocraft: relax outdated dependency version pins

### DIFF
--- a/pkgs/development/python-modules/audiocraft/default.nix
+++ b/pkgs/development/python-modules/audiocraft/default.nix
@@ -28,6 +28,12 @@ python3.pkgs.buildPythonPackage rec {
     substituteInPlace requirements.txt --replace-fail 'xformers<0.0.23' ' '
   '';
 
+  # librosa's numba @jit(cache=True) tries to write its cache next to the
+  # read-only store source during pythonImportsCheck; give it a writable dir.
+  preBuild = ''
+    export NUMBA_CACHE_DIR=$TMPDIR
+  '';
+
   # Upstream pins exact versions (torch==2.1.0, av==11.0.0, etc.) that are
   # older than what nixpkgs now provides; relax them to the available ones.
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/audiocraft/default.nix
+++ b/pkgs/development/python-modules/audiocraft/default.nix
@@ -6,6 +6,7 @@
   demucs,
   flashy,
   hydra-colorlog,
+  julius,
   torchtext,
 }:
 

--- a/pkgs/development/python-modules/audiocraft/default.nix
+++ b/pkgs/development/python-modules/audiocraft/default.nix
@@ -27,6 +27,16 @@ python3.pkgs.buildPythonPackage rec {
     substituteInPlace requirements.txt --replace-fail 'xformers<0.0.23' ' '
   '';
 
+  # Upstream pins exact versions (torch==2.1.0, av==11.0.0, etc.) that are
+  # older than what nixpkgs now provides; relax them to the available ones.
+  pythonRelaxDeps = [
+    "av"
+    "torch"
+    "torchaudio"
+    "torchvision"
+    "torchtext"
+  ];
+
   dependencies =
     with python3.pkgs;
     [


### PR DESCRIPTION
## What

After `msaf` (#24), the full `.#default` build's next blocker was `audiocraft` 1.3.0. It had three separate breakages under the current nixpkgs / Python 3.13, fixed here in order:

1. **Outdated version pins** — `pythonRuntimeDepsCheck` rejected exact pins (`torch==2.1.0`, `av==11.0.0`, `torchvision==0.16.0`, `torchtext==0.16.0`, `torchaudio<2.1.2`) older than what nixpkgs provides. → `pythonRelaxDeps` for those five.
2. **`julius` closure collision** — audiocraft pulled `julius` from `python3.pkgs` directly while `demucs` pulled the in-repo `julius`, putting two `julius 0.2.7` derivations in the closure and failing `pythonCatchConflicts`. → take `julius` as a function argument (like the other in-repo deps) so both paths resolve to the same package.
3. **numba cache dir** — importing audiocraft triggers librosa's `@jit(cache=True)` code, which tried to write its cache next to the read-only store source, failing `pythonImportsCheck`. → set `NUMBA_CACHE_DIR` to a writable dir.

## Verification

`nix build .#audiocraft` (incl. `pythonImportsCheck = [ "audiocraft" ]`) and `nix flake check` both pass in CI on this branch. The per-package `audiocraft` build is green.