### PR TITLE
mediapipe: 0.10.11 -> 1.0.0, from the upstream wheel

### DIFF
--- a/pkgs/development/python-modules/audioscrape/default.nix
+++ b/pkgs/development/python-modules/audioscrape/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   mediapipe,
   soundcloud-lib,
-  ...
 }:
 
 python3.pkgs.buildPythonApplication rec {

--- a/pkgs/development/python-modules/mediapipe/default.nix
+++ b/pkgs/development/python-modules/mediapipe/default.nix
@@ -1,39 +1,59 @@
 {
   lib,
+  stdenv,
   python3,
-  fetchFromGitHub,
+  fetchPypi,
+  autoPatchelfHook,
   opencv-contrib-python,
 }:
 
+let
+  # Upstream publishes one ABI-independent wheel per platform.
+  wheels = {
+    x86_64-linux = {
+      platform = "manylinux_2_28_x86_64";
+      hash = "sha256-B6RJRGv4iKiieH2/b8GjPaTEeXcxPe7GTRPDW/9B9tI=";
+    };
+    aarch64-linux = {
+      platform = "manylinux_2_28_aarch64";
+      hash = "sha256-5X2aYGcjssd6UbsdGUyOtzaoTFUtJFeKhTb0f2VrskE=";
+    };
+    aarch64-darwin = {
+      platform = "macosx_11_0_arm64";
+      hash = "sha256-fuR4O+QbLeNF4etx4vfnwVmlDtXCg+YMy49aYCfHCoI=";
+    };
+  };
+  wheel =
+    wheels.${stdenv.hostPlatform.system}
+      or (throw "mediapipe: no wheel for ${stdenv.hostPlatform.system}");
+in
+
 python3.pkgs.buildPythonApplication rec {
   pname = "mediapipe";
-  version = "0.10.11";
-  pyproject = true;
+  version = "1.0.0";
+  format = "wheel";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "mediapipe";
-    rev = "v${version}";
-    hash = "sha256-+9Io6ta7wzjR6r0jVHPnEvro+he2wBw9nlbdIbcjjpE=";
+  # Building from source drives Bazel, which fetches its own dependencies, so
+  # take the wheel upstream already built.
+  src = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    abi = "none";
+    inherit (wheel) platform hash;
   };
 
-  build-system = with python3.pkgs; [
-    setuptools
-    wheel
-  ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   dependencies = with python3.pkgs; [
     absl-py
-    attrs
+    certifi
     flatbuffers
-    jax
-    jaxlib-bin
     matplotlib
     numpy
     opencv-contrib-python
-    protobuf
     sounddevice
-    torch
   ];
 
   pythonImportsCheck = [ "mediapipe" ];
@@ -43,6 +63,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/google/mediapipe";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
-    mainProgram = "mediapipe";
+    platforms = builtins.attrNames wheels;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
Follow-up to #27, which left mediapipe and audioscrape as the only two red packages on `main`. Both were already red before that PR; this takes the last two.

### Why the source build could never work

`mediapipe` was pinned to a GitHub checkout of v0.10.11. Building that drives Bazel, which fetches its own external dependencies — not something that happens in the Nix sandbox. It never got that far anyway: `setup.py` carries `__version__ = 'dev'`, and modern setuptools rejects it before the build starts.

```
packaging.version.InvalidVersion: Invalid version: 'dev'
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

Patching the version string only buys you the Bazel problem.

### The wheel

Upstream now publishes ABI-independent `py3` wheels, and 1.0.0 covers `manylinux_2_28_x86_64`, `manylinux_2_28_aarch64` and `macosx_11_0_arm64` — exactly the three systems in `supportedSystems`, so the `throw` for an unknown system is unreachable here.

1.0.0 is also a much smaller artifact than the old Bazel build implies: 114 Python files and a single native object, `mediapipe/tasks/c/libmediapipe.so`. That object's `NEEDED` entries are `libm`, `libpthread`, `libdl`, `librt`, `libc` and the loader — nothing outside glibc, no libGL and no glib — so `autoPatchelfHook` on Linux is the whole story.

Dependencies follow 1.0.0's own metadata rather than the old list: `jax`, `jaxlib-bin`, `protobuf` and `torch` are gone; `certifi` and `flatbuffers` are new. Every constraint is already satisfied by nixpkgs as pinned — `absl-py~=2.3` against 2.3.1, `sounddevice~=0.5` against 0.5.5, `flatbuffers~=25.9` against 25.12.19 — so no `pythonRelaxDeps` is needed.

### audioscrape

It only ever failed as a dependent. 1.0.0 is a major version and drops `mediapipe.solutions`, but audioscrape uses the tasks API, which survives:

```python
from mediapipe.tasks.python import BaseOptions, audio
from mediapipe.tasks.python.components.containers import AudioData
```

All three resolve in the 1.0.0 wheel (`tasks/python/__init__.py` exports `audio` and `BaseOptions`; `components/containers/__init__.py` exports `AudioData`). audioscrape's own floor is `mediapipe>=0.10.1`, which 1.0.0 satisfies.

I installed the wheel into a throwaway venv and confirmed `import mediapipe` plus those three imports all succeed, so the import checks should hold rather than merely evaluate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoYkFyoXkRmv66UMNGeHJ8)_